### PR TITLE
docs: add sk installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ claude plugin marketplace add timescale/pg-aiguide
 claude plugin install pg@aiguide
 ```
 
+Or install the skills with [sk](https://github.com/803/skills-supply) on any coding agent:
+
+```bash
+sk pkg add claude-plugin pg@timescale/pg-aiguide
+sk sync
+```
+
 This plugin uses the skills available in the `skills` directory as well as our
 publicly available MCP server endpoint hosted by TigerData for searching PostgreSQL documentation.
 


### PR DESCRIPTION
`sk` is a universal package manager for agent skills (npm/cargo for agents). it works across most coding agents, handles updates, and more. It installs skills using the native installation location for each coding agent.

It also supports loading skills from claude-plugins (it'll extract the skill folders and put it into the right spot for other agents)

would you be open to adding this?
