### PR TITLE
fix(security): escape SQL identifiers in migrate.ts and searchDocs.ts

### DIFF
--- a/src/apis/searchDocs.ts
+++ b/src/apis/searchDocs.ts
@@ -5,6 +5,9 @@ import { z } from 'zod';
 import type { ServerContext } from '../types.js';
 
 type SourceType = 'tiger' | 'postgres' | 'postgis';
+
+const escId = (name: string) => `"${name.replace(/"/g, '""')}"`;
+
 const ENTITY_NAME_MAPPINGS: Partial<Record<SourceType, string>> = {
   tiger: 'timescale',
 };
@@ -135,16 +138,18 @@ export const searchDocsFactory: ApiFactory<
         )
       : query;
 
+    const s = escId(schema);
+    const e = escId(entityPrefix);
     const sql = /* sql */ `
         SELECT
           c.id::int,
           c.content,
           c.metadata::text,
           ${isSemantic ? `c.embedding <=> $1::vector(1536) AS distance` : `  -(c.content <@> to_bm25query($1, '${schema}.${entityPrefix}_chunks_content_idx')) as score`}
-        FROM ${schema}.${entityPrefix}_chunks c
+        FROM ${s}.${e}_chunks c
         ${
           version
-            ? `JOIN ${schema}.${entityPrefix}_pages p ON c.page_id = p.id
+            ? `JOIN ${s}.${e}_pages p ON c.page_id = p.id
         WHERE p.version = $2`
             : ``
         }

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -33,13 +33,14 @@ const createStateStore = (): {
         ]);
 
         // Ensure schema exists
+        const safeSchema = client.escapeIdentifier(schema);
         await client.query(/* sql */ `
-          CREATE SCHEMA IF NOT EXISTS ${schema};
+          CREATE SCHEMA IF NOT EXISTS ${safeSchema};
         `);
 
         // Ensure migrations table exists
         await client.query(/* sql */ `
-          CREATE TABLE IF NOT EXISTS ${schema}.migrations (
+          CREATE TABLE IF NOT EXISTS ${safeSchema}.migrations (
             id SERIAL PRIMARY KEY,
             set JSONB NOT NULL,
             applied_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
@@ -48,7 +49,7 @@ const createStateStore = (): {
 
         // Load the most recent migration set
         const result = await client.query(
-          /* sql */ `SELECT set FROM ${schema}.migrations ORDER BY applied_at DESC LIMIT 1`,
+          /* sql */ `SELECT set FROM ${safeSchema}.migrations ORDER BY applied_at DESC LIMIT 1`,
         );
 
         const set = result.rows.length > 0 ? result.rows[0].set : {};
@@ -65,7 +66,7 @@ const createStateStore = (): {
       try {
         // Insert the entire set as JSONB
         await client.query(
-          /* sql */ `INSERT INTO ${schema}.migrations (set) VALUES ($1)`,
+          /* sql */ `INSERT INTO ${client.escapeIdentifier(schema)}.migrations (set) VALUES ($1)`,
           [JSON.stringify(set)],
         );
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`DB_SCHEMA` (sourced from `process.env.DB_SCHEMA`) and `schema`/`entityPrefix` (in `searchDocs.ts`) were interpolated directly into SQL template literals as unquoted identifiers. If a schema name contains double-quote characters or other SQL metacharacters, the generated SQL can break or behave unexpectedly.

**Affected lines (before this PR):**
- `src/migrate.ts` lines 37, 42, 51: `CREATE SCHEMA IF NOT EXISTS ${schema}`, `CREATE TABLE IF NOT EXISTS ${schema}.migrations`, `SELECT set FROM ${schema}.migrations`
- `src/apis/searchDocs.ts` lines 149–155: `FROM ${schema}.${entityPrefix}_chunks`, `JOIN ${schema}.${entityPrefix}_pages`

## Fix

- **`src/migrate.ts`**: Call `client.escapeIdentifier(schema)` once at the top of the `load` method and use the result throughout (the `pg` `Client` class provides this method).
- **`src/apis/searchDocs.ts`**: Add a minimal inline helper `escId = (name) => '"' + name.replace(/"/g, '""') + '"'` (the standard SQL identifier quoting rule) and use it for both `schema` and `entityPrefix` in the `FROM`/`JOIN` clauses.

`entityPrefix` is already constrained to an enum-derived set of safe values, so the practical injection risk is low — but quoting both identifiers consistently is good defence-in-depth.

## Why it matters

The `DB_SCHEMA` value is operator-supplied configuration. A schema name like `public" CASCADE; DROP TABLE migrations; --` would produce malformed SQL without quoting. The fix is a one-liner using the standard pg escaping API.