### PR TITLE
docs: add Roo Code MCP install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,30 @@ Add the following to `~/.codeium/windsurf/mcp_config.json`
 
 </details>
 
+<details>
+<summary> Roo Code </summary>
+
+Add the following to your global `mcp_settings.json` (Roo Code → MCP Servers → Edit Global MCP)
+or project-level `.roo/mcp.json` (Edit Project MCP):
+
+```json
+{
+  "mcpServers": {
+    "pg-aiguide": {
+      "type": "streamable-http",
+      "url": "https://mcp.tigerdata.com/docs"
+    }
+  }
+}
+```
+
+> **Note:** Roo Code requires `"type": "streamable-http"` for remote HTTP MCP servers.
+> Using `"http"` or omitting `type` will fail to connect.
+
+See [Using MCP in Roo Code](https://docs.roocode.com/features/mcp/using-mcp-in-roo) for details.
+
+</details>
+
 ### 💡 Your First Prompt
 
 Once installed, pg-aiguide can answer Postgres questions or design schemas.


### PR DESCRIPTION
## Summary
- Adds a **Roo Code** section under Install by environment in `README.md`
- Documents global `mcp_settings.json` and project `.roo/mcp.json` config using `"type": "streamable-http"` (required by Roo for remote HTTP MCP)
- Links to Roo Code MCP docs

Closes #57

## Test plan
- [x] Diff matches existing Windsurf/Cursor/Gemini detail-block style
- [x] Confirm Roo docs URL resolves (200 after redirect)
- [ ] Maintainer smoke: paste config into Roo → MCP Servers → Edit Global MCP and verify connection to `https://mcp.tigerdata.com/docs`