### PR TITLE
Resolve relative inline links to fully-qualified URLs during scrape

### DIFF
--- a/ingest/postgis_docs.py
+++ b/ingest/postgis_docs.py
@@ -26,6 +26,7 @@ from ingest.utils.beautiful_soup import (
     fetch_page_as_soup,
     get_postgis_page_urls,
     postgis_html_to_markdown,
+    resolve_relative_links,
 )
 from ingest.utils.db import build_database_uri
 
@@ -57,6 +58,7 @@ class PostGISDocsImporter(DocumentImporter):
 
             title = extract_title(soup, fallback="PostGIS Documentation")
             soup = clean_postgis_html(soup)
+            soup = resolve_relative_links(soup, full_url)
             markdown = postgis_html_to_markdown(soup)
 
             page = Page(

--- a/ingest/postgis_docs.py
+++ b/ingest/postgis_docs.py
@@ -26,7 +26,7 @@ from ingest.utils.beautiful_soup import (
     fetch_page_as_soup,
     get_postgis_page_urls,
     postgis_html_to_markdown,
-    resolve_relative_links,
+    resolve_relative_urls,
 )
 from ingest.utils.db import build_database_uri
 
@@ -58,7 +58,7 @@ class PostGISDocsImporter(DocumentImporter):
 
             title = extract_title(soup, fallback="PostGIS Documentation")
             soup = clean_postgis_html(soup)
-            soup = resolve_relative_links(soup, full_url)
+            resolve_relative_urls(soup, full_url)
             markdown = postgis_html_to_markdown(soup)
 
             page = Page(

--- a/ingest/postgres_docs.py
+++ b/ingest/postgres_docs.py
@@ -15,6 +15,7 @@ from ingest.types import Page
 from ingest.utils.beautiful_soup import (
     extract_postgres_page_metadata,
     postgres_html_to_markdown,
+    resolve_relative_links,
 )
 
 POSTGRES_DIR = THIS_DIR / "postgres"
@@ -126,7 +127,7 @@ def build_html() -> None:
     )
 
 
-def build_markdown() -> None:
+def build_markdown(version: int) -> None:
     print("converting to markdown...")
     if MD_DIR.exists():
         shutil.rmtree(MD_DIR)
@@ -162,6 +163,8 @@ def build_markdown() -> None:
         except SystemError:
             raise SystemError(f"No div with id found in {html_file}")
 
+        page_url = f"{POSTGRES_BASE_URL}/{version}/{slug}"
+        soup = resolve_relative_links(soup, page_url)
         md_content = postgres_html_to_markdown(soup, is_refentry)
         md_content = f"""---
 title: {title_text}
@@ -229,7 +232,7 @@ def main():
         print(f"Building Postgres {version} ({tag}) documentation...")
         checkout_tag(tag)
         build_html()
-        build_markdown()
+        build_markdown(version)
         PostgresDocsImporter(version).run(conn)
 
 

--- a/ingest/postgres_docs.py
+++ b/ingest/postgres_docs.py
@@ -15,7 +15,7 @@ from ingest.types import Page
 from ingest.utils.beautiful_soup import (
     extract_postgres_page_metadata,
     postgres_html_to_markdown,
-    resolve_relative_links,
+    resolve_relative_urls,
 )
 
 POSTGRES_DIR = THIS_DIR / "postgres"
@@ -163,8 +163,8 @@ def build_markdown(version: int) -> None:
         except SystemError:
             raise SystemError(f"No div with id found in {html_file}")
 
-        page_url = f"{POSTGRES_BASE_URL}/{version}/{slug}"
-        soup = resolve_relative_links(soup, page_url)
+        page_url = f"{POSTGRES_BASE_URL}/{version}/{html_file.name}"
+        resolve_relative_urls(soup, page_url)
         md_content = postgres_html_to_markdown(soup, is_refentry)
         md_content = f"""---
 title: {title_text}

--- a/ingest/tiger_docs.py
+++ b/ingest/tiger_docs.py
@@ -18,6 +18,9 @@ from ingest.constants import (
     OPENAI_API_KEY,
     OPENAI_BASE_URL,
 )
+from ingest.utils.beautiful_soup import (
+    resolve_relative_links as resolve_relative_links_util,
+)
 from ingest.utils.db import build_database_uri
 from langchain_text_splitters import (
     MarkdownHeaderTextSplitter,
@@ -577,14 +580,20 @@ class SitemapMarkdownSpider(SitemapSpider):
         return soup
 
     def resolve_relative_links(self, soup, base_url):
-        """Rewrite relative <a href> links to fully-qualified URLs"""
-        links_resolved = 0
+        """Rewrite relative <a href> links to fully-qualified URLs.
 
-        for link in soup.find_all("a", href=True):
-            resolved = urljoin(base_url, link["href"])
-            if resolved != link["href"]:
-                link["href"] = resolved
-                links_resolved += 1
+        Delegates to the shared ingest.utils.beautiful_soup implementation so
+        the two spiders don't drift; keeps the debug-level resolved-link count.
+        """
+        hrefs_before = [link["href"] for link in soup.find_all("a", href=True)]
+        soup = resolve_relative_links_util(soup, base_url)
+        links_resolved = sum(
+            1
+            for before, link in zip(
+                hrefs_before, soup.find_all("a", href=True), strict=True
+            )
+            if link["href"] != before
+        )
 
         if links_resolved > 0:
             self.logger.debug(f"Resolved {links_resolved} relative links")

--- a/ingest/tiger_docs.py
+++ b/ingest/tiger_docs.py
@@ -18,9 +18,7 @@ from ingest.constants import (
     OPENAI_API_KEY,
     OPENAI_BASE_URL,
 )
-from ingest.utils.beautiful_soup import (
-    resolve_relative_links as resolve_relative_links_util,
-)
+from ingest.utils.beautiful_soup import resolve_relative_urls
 from ingest.utils.db import build_database_uri
 from langchain_text_splitters import (
     MarkdownHeaderTextSplitter,
@@ -44,6 +42,9 @@ with open(os.path.join(script_dir, "tiger_docs_config.toml"), "rb") as config_fp
     config = tomllib.load(config_fp)
     DOMAIN_SELECTORS = config["domain_selectors"]
     DEFAULT_SELECTORS = config["default_selectors"]
+
+# Matches an ATX markdown header line and captures its text.
+_MARKDOWN_HEADER_PATTERN = re.compile(r"^#{1,6}\s+(.+?)\s*$", re.MULTILINE)
 
 
 def add_header_breadcrumbs_to_content(content, metadata):
@@ -579,27 +580,6 @@ class SitemapMarkdownSpider(SitemapSpider):
 
         return soup
 
-    def resolve_relative_links(self, soup, base_url):
-        """Rewrite relative <a href> links to fully-qualified URLs.
-
-        Delegates to the shared ingest.utils.beautiful_soup implementation so
-        the two spiders don't drift; keeps the debug-level resolved-link count.
-        """
-        hrefs_before = [link["href"] for link in soup.find_all("a", href=True)]
-        soup = resolve_relative_links_util(soup, base_url)
-        links_resolved = sum(
-            1
-            for before, link in zip(
-                hrefs_before, soup.find_all("a", href=True), strict=True
-            )
-            if link["href"] != before
-        )
-
-        if links_resolved > 0:
-            self.logger.debug(f"Resolved {links_resolved} relative links")
-
-        return soup
-
     def convert_callouts_to_admonitions(self, soup):
         """Convert div.callout elements with h6 to admonition-style markdown callouts"""
         callouts_converted = 0
@@ -691,23 +671,27 @@ class SitemapMarkdownSpider(SitemapSpider):
 
         return soup
 
-    def extract_anchor_links(self, text):
-        """Extract markdown anchor links from text (only internal #anchors)"""
-        import re
+    def extract_heading_anchors(self, soup):
+        """Map heading text to its anchor id, for h1 to h3 headings.
 
-        # Pattern to match markdown links that are internal anchors: [text](#anchor)
-        anchor_pattern = r"\[([^\]]+)\]\(#([^)]+)\)"
+        The markdown headers keep only the text, so this map lets a chunk find
+        the anchor of the section that it came from. The first heading wins when
+        two headings have the same text.
+        """
+        heading_anchors = {}
+        for heading in soup.find_all(["h1", "h2", "h3"]):
+            anchor = heading.get("id")
+            text = heading.get_text(strip=True)
+            if anchor and text and text not in heading_anchors:
+                heading_anchors[text] = anchor
+        return heading_anchors
 
-        anchors = []
-        for match in re.finditer(anchor_pattern, text):
-            link_text = match.group(1)
-            anchor_id = match.group(2)
+    def section_url(self, url, header_text, heading_anchors):
+        """Add the section anchor to url when the heading anchor is known."""
+        anchor = heading_anchors.get(header_text) if header_text else None
+        return f"{url}#{anchor}" if anchor else url
 
-            anchors.append({"text": link_text, "anchor": anchor_id})
-
-        return anchors
-
-    def semantic_chunk_with_openai(self, markdown_text, url):
+    def semantic_chunk_with_openai(self, markdown_text, url, heading_anchors):
         """Use OpenAI to identify semantic boundaries for chunking using split identifiers"""
         try:
             # Initialize OpenAI client
@@ -796,25 +780,21 @@ Respond only with the IDs of the chunks where you believe a split should occur. 
                         # Join lines back with newlines
                         chunk_content = "\n".join(current_chunk_lines)
 
-                        # Extract anchor links from chunk content
-                        content_anchors = self.extract_anchor_links(chunk_content)
-
-                        # Create metadata
+                        # Link to the last section that starts inside this chunk
+                        headers_in_chunk = _MARKDOWN_HEADER_PATTERN.findall(
+                            chunk_content
+                        )
                         chunk_metadata = {
-                            "source_url": url,
+                            "source_url": self.section_url(
+                                url,
+                                headers_in_chunk[-1] if headers_in_chunk else None,
+                                heading_anchors,
+                            ),
                             "chunk_index": len(final_chunks),
                             "sub_chunk_index": 0,
                             "chunking_method": "semantic_openai",
                             "line_range": f"{i - len(current_chunk_lines) + 1}-{i}",
                         }
-
-                        # Add anchor information to metadata
-                        if content_anchors:
-                            chunk_metadata["anchor_links"] = content_anchors
-                            chunk_metadata["anchor_count"] = len(content_anchors)
-                            chunk_metadata["anchor_ids"] = [
-                                a["anchor"] for a in content_anchors
-                            ]
 
                         final_chunks.append(
                             {"content": chunk_content, "metadata": chunk_metadata}
@@ -829,7 +809,7 @@ Respond only with the IDs of the chunks where you believe a split should occur. 
         except Exception as e:
             raise RuntimeError(f"OpenAI semantic chunking failed for {url}: {e}")
 
-    def chunk_markdown_content_header_based(self, markdown_text, url):
+    def chunk_markdown_content_header_based(self, markdown_text, url, heading_anchors):
         """Original header-based chunking method"""
         chunks = []
 
@@ -859,15 +839,21 @@ Respond only with the IDs of the chunks where you believe a split should occur. 
         for i, doc in enumerate(header_splits):
             # Get the header metadata
             metadata = doc.metadata.copy() if hasattr(doc, "metadata") else {}
-            metadata["source_url"] = url
             metadata["chunk_index"] = i
             metadata["chunking_method"] = "header_based"
 
-            # Extract anchor links from headers (breadcrumb context)
-            header_anchors = []
-            for level in ["Header 1", "Header 2", "Header 3"]:
-                if level in metadata:
-                    header_anchors.extend(self.extract_anchor_links(metadata[level]))
+            # Link to the deepest section that contains this chunk
+            deepest_header = next(
+                (
+                    metadata[level]
+                    for level in ["Header 3", "Header 2", "Header 1"]
+                    if level in metadata
+                ),
+                None,
+            )
+            metadata["source_url"] = self.section_url(
+                url, deepest_header, heading_anchors
+            )
 
             # Split large chunks further
             sub_chunks = text_splitter.split_text(doc.page_content)
@@ -876,37 +862,19 @@ Respond only with the IDs of the chunks where you believe a split should occur. 
                 chunk_metadata = metadata.copy()
                 chunk_metadata["sub_chunk_index"] = j
 
-                # Extract anchor links from chunk content
-                content_anchors = self.extract_anchor_links(chunk_text)
-
-                # Combine header and content anchors, removing duplicates
-                all_anchors = header_anchors + content_anchors
-                unique_anchors = []
-                seen_anchors = set()
-                for anchor in all_anchors:
-                    anchor_key = (anchor["text"], anchor["anchor"])
-                    if anchor_key not in seen_anchors:
-                        unique_anchors.append(anchor)
-                        seen_anchors.add(anchor_key)
-
-                # Add anchor information to metadata
-                if unique_anchors:
-                    chunk_metadata["anchor_links"] = unique_anchors
-                    chunk_metadata["anchor_count"] = len(unique_anchors)
-                    # Also create a simple list of anchor IDs for easier searching
-                    chunk_metadata["anchor_ids"] = [a["anchor"] for a in unique_anchors]
-
                 chunks.append({"content": chunk_text, "metadata": chunk_metadata})
 
         self.logger.debug(f"Created {len(chunks)} chunks using header-based method")
         return chunks
 
-    def chunk_markdown_content(self, markdown_text, url):
+    def chunk_markdown_content(self, markdown_text, url, heading_anchors):
         """Route to appropriate chunking method based on configuration"""
         if self.chunking_method == "semantic":
-            return self.semantic_chunk_with_openai(markdown_text, url)
+            return self.semantic_chunk_with_openai(markdown_text, url, heading_anchors)
         else:  # Default to header-based
-            return self.chunk_markdown_content_header_based(markdown_text, url)
+            return self.chunk_markdown_content_header_based(
+                markdown_text, url, heading_anchors
+            )
 
     def sitemap_filter(self, entries):
         """Filter sitemap entries to only include HTML pages under the url_prefix"""
@@ -964,8 +932,10 @@ Respond only with the IDs of the chunks where you believe a split should occur. 
             if self.should_strip_data_images:
                 soup = self.strip_data_images(soup)
 
-            # Resolve relative links to fully-qualified URLs
-            soup = self.resolve_relative_links(soup, url)
+            # Resolve relative links and images to fully-qualified URLs
+            urls_resolved = resolve_relative_urls(soup, url)
+            if urls_resolved > 0:
+                self.logger.debug(f"Resolved {urls_resolved} relative URLs")
 
             # Convert callout divs to admonitions
             soup = self.convert_callouts_to_admonitions(soup)
@@ -975,6 +945,10 @@ Respond only with the IDs of the chunks where you believe a split should occur. 
 
             # Find main content
             main_content = soup.find("main") or soup
+
+            # Collect heading anchors before the markdown conversion drops them
+            heading_anchors = self.extract_heading_anchors(main_content)
+
             html_content = str(main_content)
 
             # Convert to markdown
@@ -986,7 +960,9 @@ Respond only with the IDs of the chunks where you believe a split should occur. 
 
             if self.should_chunk_content:
                 # Chunk the content
-                chunks = self.chunk_markdown_content(markdown_output, url)
+                chunks = self.chunk_markdown_content(
+                    markdown_output, url, heading_anchors
+                )
 
                 if self.db_manager is not None:
                     # Save to database

--- a/ingest/tiger_docs.py
+++ b/ingest/tiger_docs.py
@@ -576,6 +576,21 @@ class SitemapMarkdownSpider(SitemapSpider):
 
         return soup
 
+    def resolve_relative_links(self, soup, base_url):
+        """Rewrite relative <a href> links to fully-qualified URLs"""
+        links_resolved = 0
+
+        for link in soup.find_all("a", href=True):
+            resolved = urljoin(base_url, link["href"])
+            if resolved != link["href"]:
+                link["href"] = resolved
+                links_resolved += 1
+
+        if links_resolved > 0:
+            self.logger.debug(f"Resolved {links_resolved} relative links")
+
+        return soup
+
     def convert_callouts_to_admonitions(self, soup):
         """Convert div.callout elements with h6 to admonition-style markdown callouts"""
         callouts_converted = 0
@@ -939,6 +954,9 @@ Respond only with the IDs of the chunks where you believe a split should occur. 
             # Strip data: images if requested
             if self.should_strip_data_images:
                 soup = self.strip_data_images(soup)
+
+            # Resolve relative links to fully-qualified URLs
+            soup = self.resolve_relative_links(soup, url)
 
             # Convert callout divs to admonitions
             soup = self.convert_callouts_to_admonitions(soup)

--- a/ingest/utils/beautiful_soup.py
+++ b/ingest/utils/beautiful_soup.py
@@ -30,6 +30,13 @@ POSTGRES_ADMONITION_CLASSES = [
 ]
 
 
+def resolve_relative_links(soup: BeautifulSoup, base_url: str) -> BeautifulSoup:
+    """Rewrite relative <a href> links to fully-qualified URLs against base_url."""
+    for link in soup.find_all("a", href=True):
+        link["href"] = urljoin(base_url, link["href"])
+    return soup
+
+
 def clean_postgis_html(soup: BeautifulSoup) -> BeautifulSoup:
     """Remove navigation, scripts, styles, and data-URI images from PostGIS HTML."""
     for selector in POSTGIS_REMOVE_SELECTORS:

--- a/ingest/utils/beautiful_soup.py
+++ b/ingest/utils/beautiful_soup.py
@@ -30,11 +30,29 @@ POSTGRES_ADMONITION_CLASSES = [
 ]
 
 
-def resolve_relative_links(soup: BeautifulSoup, base_url: str) -> BeautifulSoup:
-    """Rewrite relative <a href> links to fully-qualified URLs against base_url."""
-    for link in soup.find_all("a", href=True):
-        link["href"] = urljoin(base_url, link["href"])
-    return soup
+# Tags whose URL attribute is made fully qualified during ingest.
+_URL_ATTRS_BY_TAG = {"a": "href", "img": "src"}
+
+
+def resolve_relative_urls(soup: BeautifulSoup, base_url: str) -> int:
+    """Rewrite relative <a href> and <img src> URLs to fully-qualified URLs.
+
+    Resolves each URL against base_url in place. Same-document references
+    (empty or fragment-only) stay as they are, because they must keep working
+    inside the page. Returns the number of URLs that changed.
+    """
+    resolved = 0
+    for tag_name, attr in _URL_ATTRS_BY_TAG.items():
+        for tag in soup.find_all(tag_name, attrs={attr: True}):
+            url = tag[attr]
+            # Keep same-document references relative.
+            if not url or url.startswith("#"):
+                continue
+            resolved_url = urljoin(base_url, url)
+            if resolved_url != url:
+                tag[attr] = resolved_url
+                resolved += 1
+    return resolved
 
 
 def clean_postgis_html(soup: BeautifulSoup) -> BeautifulSoup:


### PR DESCRIPTION
## Summary

Closes #12

When scraping documentation pages, relative `<a href>` links and `<img src>` attributes in the source HTML (e.g. `/self-hosted/latest/migration/entire-database/`) were carried verbatim into the generated markdown. This produces broken-looking inline links when an LLM quotes the returned markdown chunks, since the link target isn't resolvable without the source page's base URL.

This resolves relative URLs against the HTML source (per the issue's suggestion), before the markdown conversion step, across all three ingest pipelines.

## Changes

**Shared util (`ingest/utils/beautiful_soup.py`)**

- Adds `resolve_relative_urls(soup, base_url) -> int`, which rewrites both `<a href>` and `<img src>` in place and returns the number of URLs that changed. (`urljoin` was already imported here but unused.)
- **Skips same-document references** (empty or `#`-only hrefs). This is required, not cosmetic: `DocumentImporter.insert_chunk` builds a section deep link by matching `\((#\S+)\)` against the header text, which works because Postgres docs render headings with a self-link that markdownify preserves as `### F.1.1. Functions [#](#AMCHECK-FUNCTIONS)`. Expanding those fragments to absolute URLs breaks the regex and drops 1,931 of 2,685 chunks (72%) from section-precise links to page-level links.
- Already-absolute links, `mailto:`/`tel:`/`javascript:`/`data:` URIs, etc. are left untouched by `urljoin`.

**Call sites**

- `ingest/tiger_docs.py` — calls the util in `parse()` with the current page's `response.url` as the base, right after the existing `strip_data_images` step.
- `ingest/postgis_docs.py` — calls it with each page's resolved `full_url` as the base.
- `ingest/postgres_docs.py` — calls it with a per-page URL built from `POSTGRES_BASE_URL`, the version, and the page's HTML **filename** (threaded `version` into `build_markdown`, which didn't have it before). Uses the filename rather than the `slug` from `div[id]` because the two disagree for `index.html`, whose slug is `postgres.html`, a URL that returns 404.

**Cleanup and follow-on improvements**

- Removes the `anchor_links` / `anchor_ids` / `anchor_count` chunk metadata and `extract_anchor_links` from `tiger_docs.py`. Nothing reads these fields; they reached the model only as noise inside the opaque `metadata` JSON string, with no page URL attached, so no usable link could be built from them.
- **Tiger chunks now get real deep links**, which is what that anchor metadata looked like it was reaching for but never delivered. Tiger headings carry `id` attributes, so `parse()` collects a heading-text-to-anchor map before the markdown conversion discards it, and each chunk's `source_url` points at the section it came from. Tiger chunks previously had no deep links, unlike Postgres and PostGIS.

## Test plan

No Python test harness exists in this repo (`ingest/` has no test files and CI only runs `bun test`), so all three pipelines were run locally, using file storage for Tiger to avoid touching the shared database or spending embedding credits.

**Tiger, 12 pages, real scrape** (`--storage-type file -m 12 --chunking header`)
- 51 of 62 chunk URLs deep-linked; all 51 anchors confirmed present in the live HTML
- 0 relative links remaining, 0 relative images remaining, 0 `anchor_*` keys

**Postgres 18, full `build_markdown`, all 1,128 pages**
- 11,486 relative `.html` links resolved to absolute; 0 remaining
- 3,932 fragment-only links preserved; 1,973 header self-links byte-identical
- 1,931 / 2,685 chunks (72%) carry section deep links
- 14 randomly sampled generated URLs all return HTTP 200; no `postgres.html` base anywhere
- Corpus grows 10M → 11M (~7%), in line with the expected token cost

**PostGIS 3.5, 8 pages, live fetch**
- 72 URLs resolved, 0 relative links remaining, `../images/*.png` now absolute (verified 200)

**Lint**
- `uvx ruff check .`: 17 findings on `main` → 16 here (the change consumes the previously-unused `urljoin` import). All remaining findings pre-exist on `main` and none touch changed lines.
- `uvx ruff format --check .`: same pre-existing files flagged before and after.
- `./check` passes.

## Notes

- **This needs a re-ingest of all three sources to take effect**, since it changes both chunk content and `source_url` values.
- #134 was filed separately for UI boilerplate ("Copy Markdown / Open in Claude / ...") that occupies the first chunk of most Tiger pages. Pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
