### PR TITLE
Hide disabled skills from prompts/list

### DIFF
--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -1,3 +1,25 @@
-import { createSkillsPromptFactories } from '@tigerdata/mcp-boilerplate/skills';
+import {
+  createSkillsPromptFactories,
+  parseSkillsFlags,
+  skillVisible,
+} from '@tigerdata/mcp-boilerplate/skills';
 
-export const promptFactories = await createSkillsPromptFactories();
+const skillsPromptFactories = await createSkillsPromptFactories();
+
+// The upstream skills factories only enforce enabled_skills/disabled_skills
+// inside the prompt's fn (prompts/get), so a skill hidden via query param was
+// still advertised by prompts/list — clients would offer it, then fail with
+// "Skill not found" when loading it. Mark hidden skills as disabled so they
+// are skipped at registration and never listed for that session.
+export const promptFactories = skillsPromptFactories.map(
+  (factory): typeof factory =>
+    (context, featureFlags) => {
+      const prompt = factory(context, featureFlags);
+      return {
+        ...prompt,
+        disabled:
+          prompt.disabled ||
+          !skillVisible(prompt.name, parseSkillsFlags(featureFlags.query)),
+      };
+    },
+);


### PR DESCRIPTION
## Problem

Error tracking shows repeated failures from the Tiger CLI docs MCP proxy:

```
remote prompt request failed: calling "prompts/get": Skill not found: ghost-database.
```

The default Tiger CLI docs MCP URL is `https://mcp.tigerdata.com/docs?disabled_skills=ghost-database`, but `disabled_skills` is only enforced on the `prompts/get` path. `createSkillsPromptFactories` (from `@tigerdata/mcp-boilerplate`) registers a prompt for every loaded skill regardless of the query param, so `prompts/list` still advertises the hidden skill. Clients offer it to the LLM, the LLM tries to load it, and `prompts/get` refuses with `SkillNotFoundError`.

Reproduced against production:
- `prompts/list` on the URL **with** `?disabled_skills=ghost-database` → `ghost-database` present in the listing
- `prompts/get ghost-database` on the same session → `{"code":-32603,"message":"Skill not found: ghost-database."}`

## Fix

Wrap the skills prompt factories to set `disabled` on prompts whose skill fails the same `skillVisible` check that `prompts/get` applies. `mcpServerFactory`'s registration loop already skips `disabled` prompts per session, so hidden skills no longer appear in `prompts/list`, and list/get now agree. Covers `enabled_skills` as well, since `skillVisible` checks both.

## Verification

Drove the wrapped factories the same way `mcpServerFactory` does per session:
- `{ disabled_skills: 'ghost-database' }` → 9 prompts, ghost-database **not** advertised
- `{}` → 10 prompts, ghost-database advertised (unchanged)

`./check` passes (typecheck, lint, validate-skills, tests).