### PR TITLE
fix(ingest): stop concurrent ingests from corrupting each other

### DIFF
--- a/.github/workflows/ingest-postgis.yaml
+++ b/.github/workflows/ingest-postgis.yaml
@@ -9,6 +9,13 @@ on:
         required: true
         default: "3.6"
 
+# All versions stage into the same _tmp tables, so queue the runs instead of
+# letting them overlap. The ingest also takes a database lock, for the case of
+# a run that starts outside of this workflow.
+concurrency:
+  group: ingest-postgis-docs
+  cancel-in-progress: false
+
 jobs:
   ingest-dev:
     name: Ingest PostGIS docs for Dev

--- a/.github/workflows/ingest-postgres-docs.yaml
+++ b/.github/workflows/ingest-postgres-docs.yaml
@@ -9,6 +9,13 @@ on:
         required: true
         default: "17"
 
+# All versions stage into the same _tmp tables, so queue the runs instead of
+# letting them overlap. The ingest also takes a database lock, for the case of
+# a run that starts outside of this workflow.
+concurrency:
+  group: ingest-postgres-docs
+  cancel-in-progress: false
+
 jobs:
   ingest-dev:
     name: Ingest PostgreSQL docs for Dev

--- a/.github/workflows/ingest-tiger-docs.yaml
+++ b/.github/workflows/ingest-tiger-docs.yaml
@@ -5,6 +5,13 @@ on:
     - cron: "0 2 * * 0"
   workflow_dispatch:
 
+# Both jobs stage into the same _tmp tables, so queue the runs instead of
+# letting them overlap. The ingest also takes a database lock, for the case of
+# a run that starts outside of this workflow.
+concurrency:
+  group: ingest-tiger-docs
+  cancel-in-progress: false
+
 jobs:
   ingest-dev:
     name: Ingest Tiger docs for Dev

--- a/ingest/document_importer.py
+++ b/ingest/document_importer.py
@@ -13,6 +13,7 @@ from ingest.constants import (
 )
 from ingest.types import Chunk, Page, PageSource
 from ingest.utils.chunking import chunk_markdown_lines
+from ingest.utils.locking import acquire_ingest_lock
 from psycopg.sql import SQL, Identifier
 
 
@@ -128,6 +129,11 @@ class DocumentImporter(ABC):
 
     def init_database(self, conn: psycopg.Connection) -> None:
         """Set up _tmp tables, copying across any rows for other versions."""
+        # Hold the lock for the whole job. The _tmp tables have fixed names and
+        # get a copy of every other version, so an overlapping job for another
+        # version would discard the work of this one.
+        acquire_ingest_lock(conn, self.pages_table)
+
         print("Initializing database tables...")
 
         # Capture existing index definitions so we can recreate them after swap.

--- a/ingest/tiger_docs.py
+++ b/ingest/tiger_docs.py
@@ -20,6 +20,7 @@ from ingest.constants import (
 )
 from ingest.utils.beautiful_soup import resolve_relative_urls
 from ingest.utils.db import build_database_uri
+from ingest.utils.locking import acquire_ingest_lock
 from langchain_text_splitters import (
     MarkdownHeaderTextSplitter,
     RecursiveCharacterTextSplitter,
@@ -85,6 +86,10 @@ class DatabaseManager:
             raise RuntimeError(f"Database connection failed: {e}")
 
     def initialize(self):
+        # Hold the lock for the whole job, so a second scrape cannot drop the
+        # _tmp tables that this one is still filling.
+        acquire_ingest_lock(self.connection, "timescale_pages")
+
         with self.connection.cursor() as cursor:
             cursor.execute(
                 SQL("DROP TABLE IF EXISTS {schema}.timescale_chunks_tmp").format(

--- a/ingest/utils/locking.py
+++ b/ingest/utils/locking.py
@@ -1,0 +1,39 @@
+import zlib
+
+import psycopg
+
+# One lock guards all ingest jobs that stage into the same pair of _tmp tables.
+# The namespace keeps the keys away from other advisory lock users.
+_INGEST_LOCK_NAMESPACE = 0x70676169  # "pgai"
+
+
+def _lock_key(pages_table: str) -> int:
+    """Build the advisory lock key for a set of ingest tables.
+
+    Uses crc32, because the built-in hash() of a string changes between
+    processes, and every job must calculate the same key.
+    """
+    return _INGEST_LOCK_NAMESPACE ^ zlib.crc32(pages_table.encode())
+
+
+def acquire_ingest_lock(conn: psycopg.Connection, pages_table: str) -> None:
+    """Take the ingest lock, and wait when another ingest job holds it.
+
+    The `_tmp` tables have fixed names and hold a copy of every other version,
+    so two ingest jobs that overlap either fail on a duplicate key or silently
+    discard the version that finished first. This lock makes the jobs run one
+    after the other.
+
+    The lock is session level, so it stays after each `COMMIT`, and Postgres
+    releases it when the connection closes.
+    """
+    key = _lock_key(pages_table)
+    got_lock = conn.execute("SELECT pg_try_advisory_lock(%s)", [key]).fetchone()
+    assert got_lock is not None
+    if not got_lock[0]:
+        print(
+            f"Another ingest job is running for {pages_table}. "
+            "Waiting for it to finish..."
+        )
+        conn.execute("SELECT pg_advisory_lock(%s)", [key])
+    print(f"Holding ingest lock for {pages_table}.")


### PR DESCRIPTION
## Summary

Concurrent ingest jobs corrupt each other. Every version stages into `_tmp` tables with **fixed** names (`docs.postgres_pages_tmp`, `docs.postgis_pages_tmp`, `docs.timescale_pages_tmp`), and `init_database` drops and recreates them on startup, so a second job destroys the staging tables that the first is still filling.

Found the hard way: I dispatched all 5 Postgres versions and all 4 PostGIS versions after merging #129. Three Postgres runs and two PostGIS runs failed with

```
psycopg.errors.UniqueViolation: duplicate key value violates unique constraint "postgres_pages_tmp_url_key"
DETAIL:  Key (url)=(https://www.postgresql.org/docs/14/runtime-config-resource.html) already exists.
```

No live data was lost, because no failing run reached the final swap, but nothing was ingested either.

## Why not version-scoped `_tmp` names

That was my first instinct, and it is wrong. It would replace a loud error with **silent data loss**.

Each job copies every *other* version into its own staging table before swapping the whole table into place. With per-version staging names, two concurrent jobs become a lost update:

```
t0  v14 init:  tmp_14 = {v15_OLD, v16, v17, v18}
t1  v15 init:  tmp_15 = {v14_OLD, v16, v17, v18}
t2  v14 swap:  live   = {v14_NEW, v15_OLD, v16-18}
t3  v15 swap:  live   = {v14_OLD, v15_NEW, v16-18}   <-- v14_NEW silently lost
```

The shared `_tmp` names are not really the bug. The bug is that two jobs mutate one shared resource with no mutual exclusion.

## Changes

**`ingest/utils/locking.py`** (new)
- `acquire_ingest_lock(conn, pages_table)` takes a session-level Postgres advisory lock keyed on the pages table name. A second job prints a message and waits instead of corrupting the first.
- Uses `zlib.crc32`, **not** the built-in `hash()`. Python randomizes string hashing per process (`PYTHONHASHSEED`), so `hash()` gives each job a different key and the lock silently never engages. I hit this while writing it; verified `hash('postgres_pages')` returns a different value on every run.
- Session-level, so it survives the per-page `COMMIT` calls, and Postgres releases it when the connection closes.

**Call sites**
- `DocumentImporter.init_database` covers Postgres and PostGIS.
- `DatabaseManager.initialize` covers Tiger, which has its own DB layer.

**Workflows**
- Added a `concurrency` group to all three ingest workflows so GitHub queues runs (`cancel-in-progress: false`, since cancelling a partial ingest is not useful).
- The database lock remains the real guard: `concurrency` does not protect against a run started by hand, and the dev and prod jobs in a single run are unaffected because they target different databases.

## Test plan

Verified against the dev database:

- **Mutual exclusion**: two concurrent connections on the same key. The second waited 2.45s for the first to release and logged `Another ingest job is running for ...`. Test asserted the wait actually happened rather than just checking ordering.
- **Key stability**: `crc32`-based key is identical across processes; `hash()`-based key was not. Also confirmed the keys exceed `int4` but work fine, since `pg_advisory_lock` takes `bigint`.
- **No lock leaks**: after a simulated crash while holding the lock, a fresh session acquired it immediately.
- **Real ingest**: `postgis_docs.py --version 3.5` logs `Holding ingest lock for postgis_pages.` and completes 13 pages with a clean finalize.
- `./check` passes. `ruff check` on the new file is clean, and the repo-wide count is unchanged at 16 pre-existing findings.

## Notes

- `ingest/utils/locking.py` has no automated test, consistent with the rest of `ingest/`, which has no Python test harness. The verification above was done manually against dev.
- Follow-up worth considering separately: `finalize_database` does `DROP TABLE ... CASCADE` then `RENAME`, so there is a brief window where the live table does not exist and concurrent readers would error. This PR does not change that.
