### PR TITLE
fix(ingest): strip UI boilerplate chunk from scraped Tiger docs pages

### DIFF
--- a/ingest/tiger_docs_config.toml
+++ b/ingest/tiger_docs_config.toml
@@ -9,7 +9,11 @@
   "footer",
   "#plan-availability",
   ".sr-only",
-  ".code-block-copy-button"
+  ".code-block-copy-button",
+  # Breadcrumbs plus the "Copy Markdown" / "Open in Claude|ChatGPT|Cursor"
+  # action menu that sits above the page title. This is UI boilerplate that
+  # otherwise becomes the first chunk of nearly every page.
+  ".stl-page-nav-container"
 ]
 
 # PostGIS official documentation (postgis.net)


### PR DESCRIPTION
Closes #134

## Root cause

The boilerplate is a single container inside `<main>`, sitting above the page title:

```html
<main>
  <div class="stl-ui-prose stl-content-panel">
    <div class="stl-ui-not-prose stl-page-nav-container stl-prose-page-nav-container
                stl-page-nav-container--with-actions" data-pagefind-ignore>
      <nav class="breadcrumbs">…</nav>
      <div class="stl-ui-dropdown" data-dropdown-id="ai-dropdown-button">…</div>
    </div>
    <h1>Query tiered data</h1>
```

The `<nav class="breadcrumbs">` child is already stripped by the existing `nav` selector, which is why the leaked text was only the dropdown labels. Because this block precedes the first `#` header, `MarkdownHeaderTextSplitter` emits it as chunk 0 with empty header metadata.

## Change

One selector added to the `www.tigerdata.com` entry in `ingest/tiger_docs_config.toml`, following the existing per-domain pattern:

```toml
  ".code-block-copy-button",
  # Breadcrumbs plus the "Copy Markdown" / "Open in Claude|ChatGPT|Cursor"
  # action menu that sits above the page title. This is UI boilerplate that
  # otherwise becomes the first chunk of nearly every page.
  ".stl-page-nav-container"
```

## Selector candidates compared

I replayed `SitemapMarkdownSpider.parse()` offline over 25 pages sampled from the full 729-URL sitemap, to compare options without re-crawling:

| variant | chunks | md chars | junk chunks | prose words |
|---|---|---|---|---|
| A: before | 191 | 162,255 | 23 | 18,433 |
| B: `[data-dropdown-id="ai-dropdown-button"]` | 168 | 159,205 | 0 | 18,433 |
| C: `.stl-page-nav-container` | **166** | **158,649** | **0** | 18,359 |

B leaves a residual breadcrumb-only chunk on the two REST API reference pages, which use `div.stldocs-breadcrumbs` instead of `nav.breadcrumbs`, so the existing `nav` selector misses them. C removes the whole wrapper and catches those too.

The 74-word delta between B and C is exactly those breadcrumb link texts — navigation, not documentation, and already implied by the chunk's `source_url` metadata.

Went with C: one selector, no code change, lowest risk.

## Verification

```bash
cd ingest && PYTHONPATH=.. uv run python tiger_docs.py \
  --storage-type file -o /tmp/tigerout-after -m 12 --chunking header
```

Against a baseline scrape from `main`:

- 23/25 sampled pages and 11/12 scraped pages had the boilerplate chunk; **0 after**
- chunks: 74 → 63 (**-14.9%**), so ~15% fewer embeddings and ~15% fewer index rows for these pages
- chars: 57,855 → 54,040
- diffing all 12 before/after files with chunk markers stripped, every removed line is boilerplate (`Copy Markdown`, `Open in **Claude**`, `---`) — **zero prose lines removed**

Before:

```
---
<!-- CHUNK 1/6 -->
<!-- Metadata: {'chunk_index': 0, 'chunking_method': 'header_based', 'source_url': '…/timevector/rollup', 'sub_chunk_index': 0} -->
---

Copy Markdown
Open in **Claude**
Open in **ChatGPT**
Open in **Cursor**
---
**Copy Markdown**
**View as Markdown**
```

After, the same page starts directly at the real content:

```
---
<!-- CHUNK 1/5 -->
<!-- Metadata: {'Header 1': 'rollup()', 'chunk_index': 0, …, 'source_url': '…/timevector/rollup#_top'} -->
---

# rollup()
Combine multiple timevectors into a single timevector for re-aggregation
```

One nuance worth knowing: `docs/reference/toolkit/timevector` stayed at 7 chunks. It already had no boilerplate chunk because its nav container renders empty on that page, which confirms the selector is a no-op where there is nothing to strip.

`./check` passes.

## Note for reviewers

A full re-ingest is needed for this to take effect on existing data; it only changes how pages are parsed at scrape time.
