### PR TITLE
fix(config): validate DB_SCHEMA is a safe unquoted identifier

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,6 +4,7 @@ PGPORT=5432
 PGDATABASE=tsdb
 PGUSER=tsdbadmin
 PGPASSWORD=password
+# Must be an unquoted PostgreSQL identifier: [a-z_][a-z0-9_$]{0,62}
 DB_SCHEMA=docs
 
 # OpenAI Embedding API Key

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+
+import { DEFAULT_DB_SCHEMA, parseDbSchema } from './config.js';
+
+describe('parseDbSchema', () => {
+  test('defaults when unset', () => {
+    expect(parseDbSchema(undefined)).toBe(DEFAULT_DB_SCHEMA);
+  });
+
+  test('defaults when empty or whitespace', () => {
+    expect(parseDbSchema('')).toBe(DEFAULT_DB_SCHEMA);
+    expect(parseDbSchema('   ')).toBe(DEFAULT_DB_SCHEMA);
+  });
+
+  test('trims surrounding whitespace', () => {
+    expect(parseDbSchema('  docs  ')).toBe('docs');
+  });
+
+  test.each(['docs', '_docs', 'docs_v2', 'docs$1', 'a', 'a'.repeat(63)])(
+    'accepts %p',
+    (value) => {
+      expect(parseDbSchema(value)).toBe(value);
+    },
+  );
+
+  test.each([
+    ['uppercase', 'Docs'],
+    ['leading digit', '1docs'],
+    ['dot', 'my.docs'],
+    ['space', 'my docs'],
+    ['hyphen', 'my-docs'],
+    ['double quote', 'do"cs'],
+    ['single quote', "do'cs"],
+    ['semicolon injection', 'public" CASCADE; DROP TABLE migrations; --'],
+    ['bm25 literal injection', "docs'); DROP TABLE migrations; --"],
+    ['search_path injection', 'docs,public --search_path=evil'],
+    ['too long', 'a'.repeat(64)],
+  ])('rejects %s', (_label, value) => {
+    expect(() => parseDbSchema(value)).toThrow(/Invalid DB_SCHEMA/);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,1 +1,31 @@
-export const schema = process.env.DB_SCHEMA || 'docs';
+/**
+ * Matches a PostgreSQL identifier that is safe to interpolate unquoted:
+ * starts with a lowercase letter or underscore, followed by lowercase letters,
+ * digits, underscores, or dollar signs, up to 63 characters (NAMEDATALEN - 1).
+ */
+const UNQUOTED_IDENTIFIER = /^[a-z_][a-z0-9_$]{0,62}$/;
+
+export const DEFAULT_DB_SCHEMA = 'docs';
+
+/**
+ * Resolve and validate the database schema name.
+ *
+ * The schema name is operator-supplied configuration that gets interpolated
+ * into SQL in several different syntactic positions (bare identifiers, inside
+ * single-quoted index names passed to `to_bm25query`, and the `search_path`
+ * connection option). Rather than escaping differently at each of those call
+ * sites, we validate once here and guarantee the value is a plain unquoted
+ * identifier, which is valid in all of them.
+ */
+export const parseDbSchema = (value: string | undefined): string => {
+  const dbSchema = value?.trim() || DEFAULT_DB_SCHEMA;
+  if (!UNQUOTED_IDENTIFIER.test(dbSchema)) {
+    throw new Error(
+      `Invalid DB_SCHEMA "${dbSchema}": must be an unquoted PostgreSQL identifier ` +
+        `matching ${UNQUOTED_IDENTIFIER.source} (lowercase letters, digits, underscores, and dollar signs).`,
+    );
+  }
+  return dbSchema;
+};
+
+export const schema = parseDbSchema(process.env.DB_SCHEMA);


### PR DESCRIPTION
Alternative to #104.

## Problem

`DB_SCHEMA` is operator-supplied configuration that ends up interpolated into SQL. #104 proposed escaping it as a quoted identifier at each call site. That doesn't hold up, because the value is used in three *different* syntactic positions, each with a different escaping rule:

1. **Bare identifier** — `src/util/getDocChunkRows.ts:32-34`: `FROM ${schema}.${entityPrefix}_chunks` → needs identifier quoting (`"` doubling).
2. **Inside a single-quoted string literal** — `src/util/getDocChunkRows.ts:46,55`: `to_bm25query($1, '${schema}.${entityPrefix}_chunks_content_idx')` → needs *literal* escaping (`'` doubling). This is the one position with an actual SQL-breaking route, and #104 didn't touch it.
3. **libpq connection option** — the boilerplate migrator builds `--search_path=${schema},public` into `PGOPTIONS`. Not SQL at all; a quoted identifier here is at best untested and at worst wrong.

Escaping at the call sites therefore means two different helpers, plus duplicating them across `getDocChunkRows.ts` and the seven `migrations/*.js` files that each independently read `process.env.DB_SCHEMA`.

## Fix

Validate once, where the env var is consumed, and guarantee the value is a plain unquoted PostgreSQL identifier (`[a-z_][a-z0-9_$]{0,62}`). Such a value is valid in all three positions above, so no call site needs to change.

This is config, not untrusted user input, so failing fast at startup with a clear message is a better contract than making every call site escape-aware:

```
Invalid DB_SCHEMA "my-docs": must be an unquoted PostgreSQL identifier matching
^[a-z_][a-z0-9_$]{0,62}$ (lowercase letters, digits, underscores, and dollar signs).
```

Also trims whitespace and treats blank as unset (previously `DB_SCHEMA=" "` would have silently produced broken SQL).

## Notes on #104

Beyond missing the `to_bm25query` literal, #104's `searchDocs.ts` hunk would have broken all searches. Quoting `entityPrefix` separately from the suffix it's concatenated with produces:

```sql
FROM \"docs\".\"postgres\"_chunks c   -- syntax error
```

`entityPrefix` is also derived from a zod enum, so it never needed escaping. Its `migrate.ts` hunk no longer applies either — that file was deleted in c61d613 when migrations moved into `@tigerdata/mcp-boilerplate`.

## Follow-up (not in this PR)

The `migrations/*.js` files re-read `process.env.DB_SCHEMA` directly and bypass this validation. In practice they run in the same process as the validated entrypoint (via `cliEntrypoint`), so they're covered when invoked normally, but a standalone `bun run migrate` would skip the check. Worth consolidating separately.

## Test plan

- [x] New `src/config.test.ts` covers defaults, trimming, valid identifiers (incl. 63-char boundary), and rejection of uppercase, leading digits, dots, spaces, hyphens, quotes, over-length names, and the injection payloads for all three positions (identifier, `to_bm25query` literal, `search_path`).
- [x] `./check` passes.